### PR TITLE
bug: unable to decode confidential inputs

### DIFF
--- a/src/UniswapXAuction.sol
+++ b/src/UniswapXAuction.sol
@@ -96,10 +96,10 @@ contract UniswapXAuction is Suapp {
 
     function onchain() external payable emitOffchainLogs {}
 
-    function offchain(bytes memory data) external returns (bytes memory) {
+    function offchain() external returns (bytes memory) {
         require(Suave.isConfidential(), "Execution must be confidential");
 
-        // bytes memory data = Context.confidentialInputs();
+        bytes memory data = Context.confidentialInputs();
 
         UniswapXOrder memory order = abi.decode(data, (UniswapXOrder));
 

--- a/src/UniswapXAuction.sol
+++ b/src/UniswapXAuction.sol
@@ -170,13 +170,15 @@ contract UniswapXAuction is Suapp {
             signature: foundSignature
         });
 
-        // Sign over the orderId using the stored cosignerKey
-        bytes memory cosignerKey = Suave.confidentialRetrieve(cosignerKeyRecord, PRIVATE_KEY);
-        string memory cosignerKeyString = bytesToString(cosignerKey);
+        // // Sign over the orderId using the stored cosignerKey
+        // bytes memory cosignerKey = Suave.confidentialRetrieve(cosignerKeyRecord, PRIVATE_KEY);
+        // string memory cosignerKeyString = bytesToString(cosignerKey);
 
-        bytes memory digest = bytes.concat(orderId); // TODO: sign over cosigner data
+        // bytes memory digest = bytes.concat(orderId); // TODO: sign over cosigner data
 
-        bytes memory cosignature = Suave.signMessage(digest, Suave.CryptoSignature.SECP256, cosignerKeyString);
+        // bytes memory cosignature = Suave.signMessage(digest, Suave.CryptoSignature.SECP256, cosignerKeyString);
+
+        bytes memory cosignature = new bytes(0);
 
         cosignedOrder = CosignedUniswapXOrder({order: order, cosignature: cosignature, cosignerData: cosignerData});
     }


### PR DESCRIPTION
This function in the code on main accepts a bytes parameter and does not revert when called via the spell CLI. However, with this change (reading the data from confidential inputs), the same call reverts. As this is the only change I suspect its related to how the data is being encoded / decoded but I could be wrong.

Here's steps to reproduce:
- Clone, `forge install && forge build`
- Run local suave instance `suave-geth --suave.dev --suave.eth.external-whitelist='*'`
- Deploy the contract: `suave-geth spell deploy UniswapXAuction.sol:UniswapXAuction`
- Run `suave-geth spell conf-request --confidential-input 0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000640000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000c00000000000000000000000000000000000000000000000000000000000000000 <deployed address here> 'offchain()'` and it should revert
- The encoded bytes is correct, can verify from running `forge test --ffi -vvvv` which has a test that encodes an example order struct

Expected behavior:
```
eric.zhong@CORN-Eric-907 suapp % suave-geth spell conf-request <deployed address here> 'offchain(bytes)' '(0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000640000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000c00000000000000000000000000000000000000000000000000000000000000000)'
INFO [05-16|15:50:55.099] Running with local devchain settings
INFO [05-16|15:50:55.099] No confidential input provided, using empty string
INFO [05-16|15:50:55.099] Contract at address 0xcb632cC0F166712f09107a7587485f980e524fF6
INFO [05-16|15:50:55.099] Sending offchain confidential compute request kettle=0xB5fEAfbDD752ad52Afb7e1bD2E40432A485bBB7F
INFO [05-16|15:50:56.015] Hash of the result onchain transaction   hash=0x56199dc7b3c0cb2491f4cd805a57556f7bb1c736f19bcb4288e978809cf21913
INFO [05-16|15:50:56.015] Waiting for the transaction to be mined...
INFO [05-16|15:50:56.125] Transaction mined                        status=1 blockNum=4
INFO [05-16|15:50:56.154] Logs emitted in the onchain transaction  numLogs=8
INFO [05-16|15:50:56.154] Log emitted                              name=LogOrderId(bytes32) orderId="[52 157 236 76 48 248 227 75 113 80 74 156 242 165 198 110 207 111 254 156 164 252 148 59 243 224 134 41 207 131 167 145]"
INFO [05-16|15:50:56.154] Log emitted                              name=RFQResponse(string) quote="\"574095775006\""
INFO [05-16|15:50:56.154] Log emitted                              name=RFQResponse(string) quote="\"311043007988\""
INFO [05-16|15:50:56.154] Log emitted                              name=RFQResponse(string) quote="\"793790470057\""
INFO [05-16|15:50:56.154] Log emitted                              name=RFQResponse(string) quote="\"167381606204\""
INFO [05-16|15:50:56.154] Log emitted                              name=RFQResponse(string) quote="\"291319211712\""
INFO [05-16|15:50:56.155] Log emitted                              name=WinningQuote(uint256) quote=793,790,470,057
INFO [05-16|15:50:56.155] Log emitted                              name=RevealCosignedOrder(((address,address,uint256,uint256,address,bytes),(uint256),bytes)) order="map[cosignature:[] cosignerData:map[amountOverride:+793790470057] order:map[amount:+100 nonce:+1 signature:[] swapper:0x0000000000000000000000000000000000000002 tokenIn:0x0000000000000000000000000000000000000000 tokenOut:0x0000000000000000000000000000000000000001]]"
```